### PR TITLE
Explicitly load Git SCM in Capfile

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -6,6 +6,8 @@ require 'capistrano/setup'
 
 # Includes default deployment tasks
 require 'capistrano/deploy'
+require 'capistrano/scm/git'
+install_plugin Capistrano::SCM::Git
 
 # Includes tasks from other gems included in your Gemfile
 #


### PR DESCRIPTION
Got the following deprecation notice while deploying:

```
[Deprecation Notice] Future versions of Capistrano will not load the Git SCM
plugin by default. To silence this deprecation warning, add the following to
your Capfile after `require "capistrano/deploy"`:

    require "capistrano/scm/git"
    install_plugin Capistrano::SCM::Git
```